### PR TITLE
Remove 0x-prefix from the hex-encoded private key

### DIFF
--- a/en/wallet-generate/README.md
+++ b/en/wallet-generate/README.md
@@ -86,7 +86,7 @@ func main() {
 	}
 
 	privateKeyBytes := crypto.FromECDSA(privateKey)
-	fmt.Println(hexutil.Encode(privateKeyBytes)[2:]) // 0xfad9c8855b740a0b7ed4c221dbad0f33a83a49cad6b3fe8d5817ac83d38b6a19
+	fmt.Println(hexutil.Encode(privateKeyBytes)[2:]) // fad9c8855b740a0b7ed4c221dbad0f33a83a49cad6b3fe8d5817ac83d38b6a19
 
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)


### PR DESCRIPTION
The 0x-prefix is removed from the inline example, but it's included in Full Code