### PR TITLE
Remove 0x-prefix and uncompressed designation from the hex-encoded pu…

### DIFF
--- a/en/wallet-generate/README.md
+++ b/en/wallet-generate/README.md
@@ -95,7 +95,7 @@ func main() {
 	}
 
 	publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
-	fmt.Println(hexutil.Encode(publicKeyBytes)[4:]) // 0x049a7df67f79246283fdc93af76d4f8cdd62c4886e8cd870944e817dd0b97934fdd7719d0810951e03418205868a5c1b40b192451367f28e0088dd75e15de40c05
+	fmt.Println(hexutil.Encode(publicKeyBytes)[4:]) // 9a7df67f79246283fdc93af76d4f8cdd62c4886e8cd870944e817dd0b97934fdd7719d0810951e03418205868a5c1b40b192451367f28e0088dd75e15de40c05
 
 	address := crypto.PubkeyToAddress(*publicKeyECDSA).Hex()
 	fmt.Println(address) // 0x96216849c49358B10257cb55b28eA603c874b05E


### PR DESCRIPTION
…blic key

The 0x-prefix and uncompressed designation are removed from the inline example, but it's included in Full Code