### PR TITLE
Smart contract compile abi edits

### DIFF
--- a/en/smart-contract-compile/README.md
+++ b/en/smart-contract-compile/README.md
@@ -119,8 +119,7 @@ cd $GOPATH/src/github.com/ethereum/go-ethereum/
 make
 make devtools
 
-solc --abi Store.sol -o build
-solc --bin Store.sol -o build
+solc --abi --bin Store.sol -o build
 abigen --bin=./build/Store.bin --abi=./build/Store.abi --pkg=store --out=Store.go
 ```
 


### PR DESCRIPTION
Corrections:

- Updated solc code examples to include `-o` flag, necessary to get solc to output binary files instead of printing to terminal (https://solidity.readthedocs.io/en/v0.4.24/using-the-compiler.html)
- Tested with docker image ethereum/solc:0.4.24 which uses 0.4.24+commit.e67f0147.Linux.g++ instead of 0.4.24+commit.e67f0147.Emscripten.clang (since implementation shouldn't differ significantly between platforms).
- Updated corresponding section in Full Code.

Improvements:

- Added headings
- Clarified purpose of chapter in lead paragraph.
- Added section to use docker solc.
- Removed "version" of solc at the end of Full Code section. Instead, added version used in installation section.