### PR TITLE
Go doesn't "cast" types; corrected one instance as eg of change

### DIFF
--- a/en/signature-verify/README.md
+++ b/en/signature-verify/README.md
@@ -89,7 +89,7 @@ func main() {
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		log.Fatal("error casting public key to ECDSA")
+		log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 	}
 
 	publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)

--- a/en/smart-contract-deploy/README.md
+++ b/en/smart-contract-deploy/README.md
@@ -102,7 +102,7 @@ func main() {
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		log.Fatal("error casting public key to ECDSA")
+		log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 	}
 
 	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)

--- a/en/smart-contract-write/README.md
+++ b/en/smart-contract-write/README.md
@@ -17,7 +17,7 @@ if err != nil {
 publicKey := privateKey.Public()
 publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 if !ok {
-  log.Fatal("error casting public key to ECDSA")
+  log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 }
 
 fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
@@ -158,7 +158,7 @@ func main() {
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		log.Fatal("error casting public key to ECDSA")
+		log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 	}
 
 	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)

--- a/en/transaction-raw-create/README.md
+++ b/en/transaction-raw-create/README.md
@@ -77,7 +77,7 @@ func main() {
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		log.Fatal("error casting public key to ECDSA")
+		log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 	}
 
 	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)

--- a/en/transfer-eth/README.md
+++ b/en/transfer-eth/README.md
@@ -23,11 +23,13 @@ The function requires the public address of the account we're sending from -- wh
 publicKey := privateKey.Public()
 publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 if !ok {
-  log.Fatal("error casting public key to ECDSA")
+  log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 }
 
 fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)
 ```
+
+Here, `privateKey.Public()` returns an interface that contains our public key. We perform a type assertion with `publicKey.(<expectedType>)` to explictly set the type of our `publicKey` variable, and assign it to `publicKeyECDSA`. This allows us to use it where our program expects an input of type `*ecdsa.PublicKey`.
 
 Now we can read the nonce that we should use for the account's transaction.
 
@@ -140,7 +142,7 @@ func main() {
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		log.Fatal("error casting public key to ECDSA")
+		log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 	}
 
 	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)

--- a/en/transfer-tokens/README.md
+++ b/en/transfer-tokens/README.md
@@ -162,7 +162,7 @@ func main() {
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		log.Fatal("error casting public key to ECDSA")
+		log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 	}
 
 	fromAddress := crypto.PubkeyToAddress(*publicKeyECDSA)

--- a/en/wallet-generate/README.md
+++ b/en/wallet-generate/README.md
@@ -38,7 +38,7 @@ Converting it to hex is a similar process that we went through with the private 
 ```go
 publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 if !ok {
-  log.Fatal("error casting public key to ECDSA")
+  log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 }
 
 publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)
@@ -91,7 +91,7 @@ func main() {
 	publicKey := privateKey.Public()
 	publicKeyECDSA, ok := publicKey.(*ecdsa.PublicKey)
 	if !ok {
-		log.Fatal("error casting public key to ECDSA")
+		log.Fatal("cannot assert type: publicKey is not of type *ecdsa.PublicKey")
 	}
 
 	publicKeyBytes := crypto.FromECDSAPub(publicKeyECDSA)


### PR DESCRIPTION
Go doesn't "cast" types — would be more accurate to describe this as a **type assertion**, to correctly reflect what is going on with the Go code.

Not casting because `priv.Public()` returns an interface, which has an underlying type of `*ecdsa.PublicKey`. Calling `publicKey.(*ecdsa.PublicKey)` doesn't perform a conversion, but instead asserts `*ecdsa.PublicKey` as the resulting variable's type. If `*ecdsa.PublicKey` is not the underlying type of the variable it is performed on, the operation panics. The underlying type of the variable the type assertion is called on never changes.

If change is ok, will make changes across the rest of the guide.

source: https://stackoverflow.com/a/19579058