### PR TITLE
aligning with upstream go-ethereum -> removal of sha3 package

### DIFF
--- a/code/ecrecover.go
+++ b/code/ecrecover.go
@@ -57,7 +57,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"golang.org/x/crypto/sha3"
 	ssha "github.com/miguelmota/go-solidity-sha3"
 )
 
@@ -160,7 +160,7 @@ func SoliditySHA3(pairs []*Pair) ([]byte, error) {
 		return nil, err
 	}
 
-	d := sha3.NewKeccak256()
+	d := sha3.NewLegacyKeccak256()
 	d.Write(data)
 	return d.Sum(nil), nil
 }
@@ -246,7 +246,7 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"golang.org/x/crypto/sha3"
 	ssha "github.com/miguelmota/go-solidity-sha3"
 )
 
@@ -452,7 +452,7 @@ func TestSoliditySha3With256(t *testing.T) {
 		t.Errorf("length unexpected")
 	}
 
-	d := sha3.NewKeccak256()
+	d := sha3.NewLegacyKeccak256()
 	d.Write(g)
 	hash := d.Sum(nil)
 	if hex.EncodeToString(hash) != want {
@@ -469,7 +469,7 @@ func TestSoliditySha3With256(t *testing.T) {
 		t.Errorf("length unexpected")
 	}
 
-	d = sha3.NewKeccak256()
+	d = sha3.NewLegacyKeccak256()
 	d.Write(g)
 	hash = d.Sum(nil)
 	if hex.EncodeToString(hash) != want {

--- a/code/generate_wallet.go
+++ b/code/generate_wallet.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"golang.org/x/crypto/sha3"
 )
 
 func main() {
@@ -31,7 +31,7 @@ func main() {
 	address := crypto.PubkeyToAddress(*publicKeyECDSA).Hex()
 	fmt.Println(address) // 0x96216849c49358B10257cb55b28eA603c874b05E
 
-	hash := sha3.NewKeccak256()
+	hash := sha3.NewLegacyKeccak256()
 	hash.Write(publicKeyBytes[1:])
 	fmt.Println(hexutil.Encode(hash.Sum(nil)[12:])) // 0x96216849c49358b10257cb55b28ea603c874b05e
 }

--- a/code/transfer_tokens.go
+++ b/code/transfer_tokens.go
@@ -12,8 +12,8 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/ethereum/go-ethereum/crypto/sha3"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"golang.org/x/crypto/sha3"
 )
 
 func main() {
@@ -49,7 +49,7 @@ func main() {
 	tokenAddress := common.HexToAddress("0x28b149020d2152179873ec60bed6bf7cd705775d")
 
 	transferFnSignature := []byte("transfer(address,uint256)")
-	hash := sha3.NewKeccak256()
+	hash := sha3.NewLegacyKeccak256()
 	hash.Write(transferFnSignature)
 	methodID := hash.Sum(nil)[:4]
 	fmt.Println(hexutil.Encode(methodID)) // 0xa9059cbb

--- a/code/util/util.go
+++ b/code/util/util.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"golang.org/x/crypto/sha3"
 	"github.com/shopspring/decimal"
 )
 
@@ -17,7 +17,7 @@ import (
 func PublicKeyBytesToAddress(publicKey []byte) common.Address {
 	var buf []byte
 
-	hash := sha3.NewKeccak256()
+	hash := sha3.NewLegacyKeccak256()
 	hash.Write(publicKey[1:]) // remove EC prefix 04
 	buf = hash.Sum(nil)
 	address := buf[12:]


### PR DESCRIPTION
Had to make this change for my stuff, and I found this repo so useful I figured others might benefit. Upstream geth removed `github.com/ethereum/go-ethereum/crypto/sha3`. The `golang.org/x/crypto/sha3` package contains the same code for `NewKeccak256` as `NewLegacyKeccak256`.

I didn't test - ecrecover.go doesn't compile - but, I figure if you don't want the PR, it will at least be a reminder that this change has to be made. 