### PR TITLE
Update blocks.go

### DIFF
--- a/code/blocks.go
+++ b/code/blocks.go
@@ -29,7 +29,7 @@ func main() {
 	}
 
 	fmt.Println(block.Number().Uint64())     // 5671744
-	fmt.Println(block.Time().Uint64())       // 1527211625
+	fmt.Println(block.Time())       // 1527211625
 	fmt.Println(block.Difficulty().Uint64()) // 3217000136609065
 	fmt.Println(block.Hash().Hex())          // 0x9e8751ebb5069389b855bba72d94902cc385042661498a415979b7b6ee9ba4b9
 	fmt.Println(len(block.Transactions()))   // 144


### PR DESCRIPTION
When using fmt.Println(block.Time().Uint64()) gives an error so which says type uint 64 has no field or method uint64 but when change it to fmt.Println(block.Time()) it gives the desired time.