### PR TITLE
Fixed path to the Address Check content

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The e-book is avaiable in different formats.
   * [Generating New Wallets](en/wallet-generate/README.md)
   * [Keystores](en/keystore/README.md)
   * [HD Wallets](en/hd-wallet/README.md)
-  * [Address Check](address-check/README.md)
+  * [Address Check](en/address-check/README.md)
 * [Transactions](en/transactions/README.md)
   * [Querying Blocks](en/block-query/README.md)
   * [Querying Transactions](en/transaction-query/README.md)


### PR DESCRIPTION
I've added the en path prefix to the Address Check link in order to redirect to the the right file.
