### PR TITLE
change default ethereum rpc gateway

### DIFF
--- a/code/account_balance.go
+++ b/code/account_balance.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/code/address_check.go
+++ b/code/address_check.go
@@ -16,7 +16,7 @@ func main() {
 	fmt.Printf("is valid: %v\n", re.MatchString("0x323b5d4c32345ced77393b3530b1eed0f346429d")) // is valid: true
 	fmt.Printf("is valid: %v\n", re.MatchString("0xZYXb5d4c32345ced77393b3530b1eed0f346429d")) // is valid: false
 
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/code/blocks.go
+++ b/code/blocks.go
@@ -10,7 +10,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/code/client.go
+++ b/code/client.go
@@ -8,7 +8,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/code/contract_read_erc20.go
+++ b/code/contract_read_erc20.go
@@ -14,7 +14,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/code/event_read_0xprotocol.go
+++ b/code/event_read_0xprotocol.go
@@ -50,7 +50,7 @@ type LogError struct {
 }
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/code/event_read_by_transaction.go
+++ b/code/event_read_by_transaction.go
@@ -11,7 +11,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/code/event_read_erc20.go
+++ b/code/event_read_erc20.go
@@ -30,7 +30,7 @@ type LogApproval struct {
 }
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/code/helper/helper_test.go
+++ b/code/helper/helper_test.go
@@ -15,7 +15,7 @@ var s *Service
 
 func init() {
 	service, err := New(&Options{
-		ProviderURI: "wss://mainnet.infura.io/ws",
+		ProviderURI: "wss://cloudflare-eth.com/ws",
 	})
 	if err != nil {
 		panic(err)

--- a/code/rpc_call.go
+++ b/code/rpc_call.go
@@ -11,7 +11,7 @@ import (
 // https://stackoverflow.com/questions/53237759/how-to-correctly-send-rpc-call-using-golang-to-get-smart-contract-owner/53260846#53260846
 
 func main() {
-	client, err := rpc.DialHTTP("https://mainnet.infura.io")
+	client, err := rpc.DialHTTP("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/code/rpc_client_version.go
+++ b/code/rpc_client_version.go
@@ -7,7 +7,7 @@ import (
 )
 
 func main() {
-	client, err := rpc.DialHTTP("https://mainnet.infura.io")
+	client, err := rpc.DialHTTP("https://cloudflare-eth.com")
 	if err != nil {
 		panic(err)
 	}

--- a/code/transactions.go
+++ b/code/transactions.go
@@ -12,7 +12,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/en/account-balance/README.md
+++ b/en/account-balance/README.md
@@ -68,7 +68,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/en/address-check/README.md
+++ b/en/address-check/README.md
@@ -74,7 +74,7 @@ func main() {
 	fmt.Printf("is valid: %v\n", re.MatchString("0x323b5d4c32345ced77393b3530b1eed0f346429d")) // is valid: true
 	fmt.Printf("is valid: %v\n", re.MatchString("0xZYXb5d4c32345ced77393b3530b1eed0f346429d")) // is valid: false
 
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/en/block-query/README.md
+++ b/en/block-query/README.md
@@ -69,7 +69,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/en/client-setup/README.md
+++ b/en/client-setup/README.md
@@ -9,7 +9,7 @@ Setting up the Ethereum client in Go is a fundamental step required for interact
 You can connect to the infura gateway if you don't have an existing client. Infura manages a bunch of Ethereum [geth and parity] nodes that are secure, reliable, scalable and lowers the barrier to entry for newcomers when it comes to plugging into the Ethereum network.
 
 ```go
-client, err := ethclient.Dial("https://mainnet.infura.io")
+client, err := ethclient.Dial("https://cloudflare-eth.com")
 ```
 
 You may also pass the path to the IPC endpoint file if you have a local instance of geth running.
@@ -70,7 +70,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/en/event-read-0xprotocol/README.md
+++ b/en/event-read-0xprotocol/README.md
@@ -91,7 +91,7 @@ type LogError struct {
 Initialize the ethereum client:
 
 ```go
-client, err := ethclient.Dial("https://mainnet.infura.io")
+client, err := ethclient.Dial("https://cloudflare-eth.com")
 if err != nil {
   log.Fatal(err)
 }
@@ -385,7 +385,7 @@ type LogError struct {
 }
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/en/event-read-erc20/README.md
+++ b/en/event-read-erc20/README.md
@@ -41,7 +41,7 @@ type LogApproval struct {
 Initialize the ethereum client:
 
 ```go
-client, err := ethclient.Dial("https://mainnet.infura.io")
+client, err := ethclient.Dial("https://cloudflare-eth.com")
 if err != nil {
   log.Fatal(err)
 }
@@ -230,7 +230,7 @@ type LogApproval struct {
 }
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/en/smart-contract-read-erc20/README.md
+++ b/en/smart-contract-read-erc20/README.md
@@ -142,7 +142,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/en/transaction-query/README.md
+++ b/en/transaction-query/README.md
@@ -96,7 +96,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/zh/account-balance/README.md
+++ b/zh/account-balance/README.md
@@ -68,7 +68,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/zh/address-check/README.md
+++ b/zh/address-check/README.md
@@ -74,7 +74,7 @@ func main() {
 	fmt.Printf("is valid: %v\n", re.MatchString("0x323b5d4c32345ced77393b3530b1eed0f346429d")) // is valid: true
 	fmt.Printf("is valid: %v\n", re.MatchString("0xZYXb5d4c32345ced77393b3530b1eed0f346429d")) // is valid: false
 
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/zh/block-query/README.md
+++ b/zh/block-query/README.md
@@ -67,7 +67,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/zh/client-setup/README.md
+++ b/zh/client-setup/README.md
@@ -9,7 +9,7 @@
 若您没有现有以太坊客户端，您可以连接到infura网关。Infura管理着一批安全，可靠，可扩展的以太坊[geth和parity]节点，并且在接入以太坊网络时降低了新人的入门门槛。
 
 ```go
-client, err := ethclient.Dial("https://mainnet.infura.io")
+client, err := ethclient.Dial("https://cloudflare-eth.com")
 ```
 
 若您运行了本地geth实例，您还可以将路径传递给IPC端点文件。
@@ -70,7 +70,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/zh/event-read-0xprotocol/README.md
+++ b/zh/event-read-0xprotocol/README.md
@@ -95,7 +95,7 @@ type LogError struct {
 初始化以太坊客户端：
 
 ```go
-client, err := ethclient.Dial("https://mainnet.infura.io")
+client, err := ethclient.Dial("https://cloudflare-eth.com")
 if err != nil {
   log.Fatal(err)
 }
@@ -388,7 +388,7 @@ type LogError struct {
 }
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/zh/event-read-erc20/README.md
+++ b/zh/event-read-erc20/README.md
@@ -41,7 +41,7 @@ type LogApproval struct {
 初始化以太坊客户端
 
 ```go
-client, err := ethclient.Dial("https://mainnet.infura.io")
+client, err := ethclient.Dial("https://cloudflare-eth.com")
 if err != nil {
   log.Fatal(err)
 }
@@ -231,7 +231,7 @@ type LogApproval struct {
 }
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/zh/smart-contract-read-erc20/README.md
+++ b/zh/smart-contract-read-erc20/README.md
@@ -143,7 +143,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/zh/transaction-query/README.md
+++ b/zh/transaction-query/README.md
@@ -97,7 +97,7 @@ import (
 )
 
 func main() {
-	client, err := ethclient.Dial("https://mainnet.infura.io")
+	client, err := ethclient.Dial("https://cloudflare-eth.com")
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
When I tried the example, I got an error. It looks like `mainnet.infura.io` needs a project ID and It's a little unfriendly for beginners. I changed the default gateway address to one available out of the box.
```
403 Forbidden {"jsonrpc":"2.0","id":1,"error":{"code":-32600,"message":"project ID is required","data":{"reason":"project ID not provided","see":"https://infura.io/dashboard"}}}
```